### PR TITLE
only run setInitialColumnWidth if there are columns

### DIFF
--- a/src/mm-grid/mm-grid.js
+++ b/src/mm-grid/mm-grid.js
@@ -76,15 +76,17 @@
 		},
 
 		setInitialColumnWidth: function() {
-			var setInitialWidth = this.columns.every(function(column){
-				return column.width === null || column.width === undefined;
-			});
-
-			if(setInitialWidth) {
-				var initialWidth = 100 / this.columns.length;
-				this.columns.forEach(function(column) {
-					column.width = initialWidth + "%";
+			if(this.$.columns.getDistributedNodes().length > 0) {
+				var setInitialWidth = this.columns.every(function(column){
+					return column.width === null || column.width === undefined;
 				});
+
+				if(setInitialWidth) {
+					var initialWidth = 100 / this.columns.length;
+					this.columns.forEach(function(column) {
+						column.width = initialWidth + "%";
+					});
+				}
 			}
 		},
 


### PR DESCRIPTION
We would like to use mm-grid with ajax, however if you create an empty mm-grid it will throw an error. This just checks that columns exist before trying to resize them.