### PR TITLE
add "blank" validation to mm-input

### DIFF
--- a/src/mm-input/doc.json
+++ b/src/mm-input/doc.json
@@ -16,7 +16,7 @@
 			"description":"Define which type of validation the textarea should perform.",
 			"optional":true,
 			"default":"none",
-			"options":["empty", "int", "decimal", "email", "alpha"]
+			"options":["empty", "int", "decimal", "email", "alpha", "blank"]
 		},
 		{
 			"name":"search",

--- a/src/mm-input/mm-input.js
+++ b/src/mm-input/mm-input.js
@@ -125,6 +125,8 @@ Polymer('mm-input', {
 				return this.email.test(this.value);
 			case "alpha":
 				return this.alpha.test(this.value);
+			case "blank":
+				return this.value.trim().length > 0;
 			default:
 				return true;
 		}


### PR DESCRIPTION
Use case: 
validating that inputs contain more than just blank spaces.