### PR TITLE
mm-calendar port

### DIFF
--- a/src/mm-calendar/index.html
+++ b/src/mm-calendar/index.html
@@ -36,20 +36,35 @@
 	</head>
 	<body>
 		<mm-calendar id="cal1"></mm-calendar>
-		<mm-calendar id="cal2"></mm-calendar>
+		<mm-calendar id="cal2" disable-future="true"></mm-calendar>
 		<mm-calendar id="cal3" disabled></mm-calendar>
-		<template is="auto-binding">
-			<mm-calendar id="cal4" mode="left" pairDate="{{$.cal5.date}}" class="pair" disablePast="true"></mm-calendar>
-			<mm-calendar id="cal5" mode="right" pairDate="{{$.cal4.date}}" class="pair" disablePast="true"></mm-calendar>
+		<template id="calPair" is="dom-bind">
+			<mm-calendar id="cal4" mode="left" date="{{leftDate}}" pair-date="{{rightDate}}" class="pair" disable-past="true"></mm-calendar>
+			<mm-calendar id="cal5" mode="right" date="{{rightDate}}" pair-date="{{leftDate}}" class="pair" disable-past="true"></mm-calendar>
 		</template>
 		<script>
 			var cal1, cal2, cal3;
 
-			window.addEventListener("polymer-ready", function() { 
+			window.addEventListener("WebComponentsReady", function() { 
 				cal1 = document.getElementById("cal1");
 				cal2 = document.getElementById("cal2");
-				cal3 = document.getElementById("cal2");
-				
+				cal3 = document.getElementById("cal3");
+
+				cal1.addEventListener('calendar-select', function(e) {
+					console.log('Date selected:');
+					console.log(e);
+				});
+
+				cal2.addEventListener('calendar-select', function(e) {
+					console.log('Date selected:');
+					console.log(e);
+				});
+
+				cal3.addEventListener('calendar-select', function(e) {
+					console.log('Date selected:');
+					console.log(e);
+				});
+
 			});
 		</script>
 	</body>

--- a/src/mm-calendar/mm-calendar.html
+++ b/src/mm-calendar/mm-calendar.html
@@ -3,39 +3,41 @@
  * Copyright (c) 2015 MediaMath Inc. All rights reserved.
  * This code may only be used under the BSD style license found at http://mediamath.github.io/strand/LICENSE.txt
  
--->
-<link rel="import" href="../../bower_components/polymer/polymer.html">
+--><html><head><link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../mm-header/mm-header.html">
 <link rel="import" href="../mm-icon/mm-icon.html">
+<link rel="import" href="../shared/behaviors/stylable.html">
 <link rel="import" href="../shared/js/colors.html">
 <link rel="import" href="../shared/js/datautils.html">
 <link rel="import" href="../shared/js/moment.html">
 <link rel="import" href="../shared/js/momentrange.html">
 
-<polymer-element name="mm-calendar" attributes="days month year">
-	<template>
-		<link href="mm-calendar.css" rel="stylesheet" type="text/css"/>
+<dom-module id="mm-calendar">
+  <link rel="import" type="css" href="mm-calendar.css">
+  <template>
 		<div class="month-year">
-			<mm-icon class="left-arrow" type="cycle-arrow" on-click="{{decrMonth}}" width="13" height="13" hoverColor="[[ARROW_HOVER_COLOR]]"></mm-icon>
-			<mm-header class="header" size="small">{{month}} {{year}}</mm-header>
-			<mm-icon class="right-arrow"type="cycle-arrow" on-click="{{incrMonth}}" width="13" height="13" hoverColor="[[ARROW_HOVER_COLOR]]"></mm-icon>
+			<mm-icon class="left-arrow" type="cycle-arrow" on-tap="_decrMonth" width="13" height="13"></mm-icon>
+			<mm-header class="header" size="small"><span>{{month}}</span> <span>{{year}}</span></mm-header>
+			<mm-icon class="right-arrow" type="cycle-arrow" on-tap="_incrMonth" width="13" height="13"></mm-icon>
 		</div>
 		<div class="calendar">
 			<div class="headings">
-				<template repeat="{{ header in headers }}">
-					<div class="{{header.class}}">
+				<template is="dom-repeat" items="{{headers}}" as="header">
+					<div class$="{{header.class}}">
 						<span>{{header.label}}</span>
 					</div>
 				</template>
-			</div> 
-			<div id="days" class="days" on-tap="{{handleTap}}">
-				<template repeat="{{ day in days }}">
-					<div id="day{{day.value}}" class="day {{day.class | tokenList}}">
-						<span value="{{day.value}}">{{day.label}}</span>
+			</div>
+			<div id="days" class="days" on-tap="_handleTap">
+				<div style="min-height: 16px;">
+				<template is="dom-repeat" items="{{days}}" as="day">
+					<div id$="{{_dayId(day)}}" class$="{{_dayClass(day)}}">
+						<span value$="{{day.value}}">{{day.label}}</span>
 					</div>
 				</template>
+				</div>
 			</div>
 		</div>
 	</template>
-	<script src="mm-calendar.js"></script>
-</polymer-element>
+  <script src="mm-calendar.js"></script>
+</dom-module>

--- a/src/mm-calendar/mm-calendar.scss
+++ b/src/mm-calendar/mm-calendar.scss
@@ -32,7 +32,6 @@
 	opacity: 0.5;
 }
 
-polyfill-next-selector { content: ".calendar, .month-year" }
 .calendar, .month-year {
 	box-sizing: border-box;
 	background: $color-F0;
@@ -41,12 +40,10 @@ polyfill-next-selector { content: ".calendar, .month-year" }
 	padding: 3px;
 }
 
-polyfill-next-selector { content: ".calendar" }
 .calendar {
 	padding-bottom: 2px;
 }
 
-polyfill-next-selector { content: ".month-year" }
 .month-year {
 	@include display(flex);
 	@include align-items(center);
@@ -62,12 +59,10 @@ polyfill-next-selector { content: ".month-year" }
 	}
 }
 
-polyfill-next-selector { content: ".days, .headings" }
 .days, .headings {
 	@include clearfix;
 }
 
-polyfill-next-selector { content: ".day, .heading" }
 .heading, .day {
 	@include fontSmoothing();
 	box-sizing: border-box;
@@ -80,7 +75,6 @@ polyfill-next-selector { content: ".day, .heading" }
 	margin-bottom: 1px;
 }
 
-polyfill-next-selector { content: ".day span, .heading span" }
 .day span, .heading span {
 	box-sizing: border-box;
 	@include fontSmoothing();
@@ -96,7 +90,6 @@ polyfill-next-selector { content: ".day span, .heading span" }
 	z-index: 1;
 }
 
-polyfill-next-selector { content: ".day" }
 .day { 
 	&.active {
 		cursor: pointer;
@@ -186,7 +179,6 @@ polyfill-next-selector { content: ".day" }
 	}
 }
 
-polyfill-next-selector { content: ".heading" }
 .heading {
 	span {
 		color: $color-A18;


### PR DESCRIPTION
since you can't bind to the $ hash anymore, to pair two calendars you need to bind both `date` and `pair-date` attributes e.g.
```html
<template id="calPair" is="dom-bind">
	<mm-calendar id="cal4" mode="left" date="{{leftDate}}" pair-date="{{rightDate}}" class="pair" disable-past="true"></mm-calendar>
	<mm-calendar id="cal5" mode="right" date="{{rightDate}}" pair-date="{{leftDate}}" class="pair" disable-past="true"></mm-calendar>
</template>
```