### PR TITLE
non scrollable behavior update for multi-panels

### DIFF
--- a/src/shared/behaviors/nonscrollable.html
+++ b/src/shared/behaviors/nonscrollable.html
@@ -32,7 +32,7 @@
 		} else {
 			// only reset body if no opened instance
 			if (_openedInstances.size === 0) {
-				document.body.style.pointerEvents = this.__oldBodyPointer || '';
+				document.body.style.pointerEvents = __oldBodyPointer || '';
 			}
 		}
 	}

--- a/src/shared/behaviors/nonscrollable.html
+++ b/src/shared/behaviors/nonscrollable.html
@@ -8,15 +8,15 @@
 */
 (function(scope) {
 
-	var _openedInstances = [];
+	var _openedInstances = new Set();
 	var __oldBodyPointer;
 
 	function _addOpenedInstance(instance) {
-		_openedInstances.push(instance);
+		_openedInstances.add(instance);
 	}
 
 	function _removeOpenedInstance(instance) {
-		_openedInstances.splice(_openedInstances.indexOf(instance), 1);
+		_openedInstances.delete(instance);
 	}
 
 	// There are cases where multiple panels can be opened simultaneously
@@ -25,13 +25,13 @@
 		var bodyPointer = document.body.style.pointerEvents;
 		if (state === 'opened') {
 			// Only set body on first opened instance
-			if (_openedInstances.length === 1) {
+			if (_openedInstances.size === 1) {
 				__oldBodyPointer = document.body.style.pointerEvents;
 				document.body.style.pointerEvents = 'none';
 			}
 		} else {
 			// only reset body if no opened instance
-			if (_openedInstances.length === 0) {
+			if (_openedInstances.size === 0) {
 				document.body.style.pointerEvents = this.__oldBodyPointer || '';
 			}
 		}

--- a/src/shared/behaviors/nonscrollable.html
+++ b/src/shared/behaviors/nonscrollable.html
@@ -7,6 +7,35 @@
 
 */
 (function(scope) {
+
+	var _openedInstances = [];
+	var __oldBodyPointer;
+
+	function _addOpenedInstance(instance) {
+		_openedInstances.push(instance);
+	}
+
+	function _removeOpenedInstance(instance) {
+		_openedInstances.splice(_openedInstances.indexOf(instance), 1);
+	}
+
+	// There are cases where multiple panels can be opened simultaneously
+	// (a panel layout nested inside another panel for instance).
+	function _checkDocumentBody(state) {
+		var bodyPointer = document.body.style.pointerEvents;
+		if (state === 'opened') {
+			// Only set body on first opened instance
+			if (_openedInstances.length === 1) {
+				__oldBodyPointer = document.body.style.pointerEvents;
+				document.body.style.pointerEvents = 'none';
+			}
+		} else {
+			// only reset body if no opened instance
+			if (_openedInstances.length === 0) {
+				document.body.style.pointerEvents = this.__oldBodyPointer || '';
+			}
+		}
+	}
 	
 	scope.NonScrollable = {
 		properties: {
@@ -16,41 +45,48 @@
 			}
 		},
 
-		observers:["_handleState(state)"],
+		__oldInstancePointer: null,
+
+		observers:['_handleState(state)'],
 
 		detached: function() {
-			this.style.pointerEvents = this.__oldInstancePointer  || "";
-			if(this._target && this._target.style) this._target.style.pointerEvents = this.__oldTargetPointer || "";
-			document.body.style.pointerEvents = this.__oldBodyPointer || "";
+			this._enable();
 		},
 
-		_handleState:function() {
+		_disable: function() {
+			_addOpenedInstance(this);
+			_checkDocumentBody('opened');
+
+			this.__oldInstancePointer = this.style.pointerEvents;
+			this.style.pointerEvents = 'all';
+
+			if (this._target && this._target.style) {
+				this.__oldTargetPointer = this._target.style.pointerEvents;
+				this._target.style.pointerEvents = 'all';
+			}
+		},
+
+		_enable: function() {
+			_removeOpenedInstance(this);
+			_checkDocumentBody('closed');
+
+			this.style.pointerEvents = this.__oldInstancePointer || '';
+
+			if (this._target && this._target.style) {
+				this._target.style.pointerEvents = this.__oldTargetPointer || '';
+			}
+		},
+
+		_handleState:function(state) {
 			if (this.disableScroll) {
-				this.debounce("nonscrollable", this._updateStyles);
-			}
-		},
-
-		_updateStyles: function() {
-			if (this.state === "opened") {
-				
-				this.__oldInstancePointer = this.style.pointerEvents;
-				this.style.pointerEvents = "all";
-
-				if(this._target && this._target.style) {
-					this.__oldTargetPointer = this._target.style.pointerEvents;
-					this._target.style.pointerEvents = "all";
+				if (state === 'opened') {
+					this._disable();
+				} else {
+					this._enable();
 				}
-
-				this.__oldBodyPointer = document.body.style.pointerEvents;
-				document.body.style.pointerEvents = "none";
-			} else {
-				this.style.pointerEvents = this.__oldInstancePointer  || "";
-				if(this._target && this._target.style) this._target.style.pointerEvents = this.__oldTargetPointer || "";
-				document.body.style.pointerEvents = this.__oldBodyPointer || "";
 			}
-		},
-
-	};
+		}
+	}
 
 })(window.StrandTraits = window.StrandTraits || {});
 </script>


### PR DESCRIPTION
@dlasky @shuwen @jcmoore FYI

In a panel-within-panel scenario, closing by clicking outside was causing the `pointer-events:none` to get "stuck" on the body... therefor, nothing clickable.

