### PR TITLE
Various corrections to dropdown list items

### DIFF
--- a/src/shared/behaviors/positionable-dropdown.json
+++ b/src/shared/behaviors/positionable-dropdown.json
@@ -14,7 +14,8 @@
 			"name":"overflowWidth",
 			"type":"Number",
 			"description":"The maximum width of the dropdown panel, after which it will truncate its content. If overflowWidth is set, the element will ignore its overflow property.",
-			"optional":true
+			"optional":true,
+			"attribute":"overflow-width"
 		}
 	]
 }

--- a/src/shared/sass/_dropdown.scss
+++ b/src/shared/sass/_dropdown.scss
@@ -130,12 +130,6 @@ $border-color: $color-A18 !default;
 			padding: 0 8px 0 10px;
 		}
 	}
-
-	#container > ::content strand-list-item,
-	strand-list-item {
-		font-size: 11px !important;
-		line-height: 13px !important;
-	}
 }
 
 :host([skinless]) {

--- a/src/strand-dropdown/index.html
+++ b/src/strand-dropdown/index.html
@@ -100,12 +100,12 @@
 	<body>
 		<div class="col c1">
 
-			<p><span class="bold">Dropdown:</span> Dynamic data dropdown - first value "pre-selected"</p>
+			<p><span class="bold">Dropdown:</span> Dynamic data dropdown - first value "pre-selected", overflow visible, overflow width set</p>
 			<strand-dropdown id="dataTest" overflow="visible" max-items="10" overflow-width="200" placeholder="Some Longer Label" unresolved>
 			</strand-dropdown>
 			<hr/>
 
-			<p><span class="bold">Dropdown:</span> Dynamic data dropdown - first value "pre-selected"</p>
+			<p><span class="bold">Dropdown:</span> Dynamic data dropdown</p>
 			<strand-dropdown id="dataTestShort" placeholder="Some Label" unresolved></strand-dropdown>
 			<hr/>
 
@@ -156,7 +156,7 @@
 				</strand-dropdown>
 				<hr/>
 
-				<p><span class="bold">Dropdown:</span> Dynamic data dropdown - first value "pre-selected"</p>
+				<p><span class="bold">Dropdown:</span> Dynamic data dropdown hidden at first - first value "pre-selected"</p>
 				<strand-dropdown id="dataTestHidden" placeholder="Some Longer Label" unresolved></strand-dropdown>
 				<hr/>
 			</div>
@@ -166,6 +166,7 @@
 		<div class="vr"></div>
 
 		<div class="col c1">
+
 			<p><span class="bold">Dropdown:</span> List options wider than label</p>
 			<strand-dropdown unresolved>
 				<strand-list-item unresolved>strand-list-item 01</strand-list-item>
@@ -185,7 +186,7 @@
 			</strand-dropdown>
 			<hr/>
 
-			<p><span class="bold">Dropdown:</span> List options wider than label with search added</p>
+			<p><span class="bold">Dropdown:</span> List options wider than label with search added, fitparent</p>
 			<strand-dropdown fitparent="true" unresolved>
 				<strand-input search="true" clear="true" placeholder="Search"></strand-input>
 				<strand-list-item unresolved>strand-list-item with an exremely long label or name in here 01</strand-list-item>
@@ -194,13 +195,6 @@
 				<strand-list-item unresolved>strand-list-item 04</strand-list-item>
 			</strand-dropdown>
 			<hr/>
-
-		</div>
-
-		<div class="vr"></div>
-
-		<div class="col c1">
-
 			<p><span class="bold">Dropdown:</span> List with overflow: visible</p>
 			<strand-dropdown placeholder="Select One" overflow="visible">
 				<strand-list-item unresolved>strand-list-item with an exremely long label or name in here 01</strand-list-item>
@@ -227,6 +221,12 @@
 			</strand-dropdown>
 			<hr/>
 
+		</div>
+
+		<div class="vr"></div>
+
+		<div class="col c1">
+
 			<p><span class="bold">Dropdown:</span> List with overflow: visible with search added</p>
 			<strand-dropdown placeholder="Select One" overflow="visible">
 				<strand-input search="true" clear="true" placeholder="Search"></strand-input>
@@ -237,7 +237,7 @@
 			</strand-dropdown>
 			<hr/>
 
-			<p><span class="bold">Dropdown:</span> List with overflow: overflowWidth set</p>
+			<p><span class="bold">Dropdown:</span> Size small, overflow: visible, overflow-width set</p>
 			<strand-dropdown placeholder="Select One Please" overflow="visible" overflow-width="250" size="small">
 				<strand-list-item unresolved>strand-list-item with an exremely long label or name in here 00</strand-list-item>
 				<strand-list-item unresolved>strand-list-item with an exremely long label or name in here 01</strand-list-item>
@@ -273,8 +273,8 @@
 				<strand-list-item unresolved>strand-list-item with an exremely long label or name in here 31</strand-list-item>
 			</strand-dropdown>
 			<hr/>
-			<p><span class="bold">Dropdown:</span> Dropdown small and skinless</p>
-			<strand-dropdown placeholder="Select" size="small" skinless overflow="visible" maxItems="7" unresolved>
+			<p><span class="bold">Dropdown:</span> Size small and skinless</p>
+			<strand-dropdown placeholder="Select" size="small" skinless overflow="visible" max-items="7" unresolved>
 				<strand-input search="true" clear="true" size="small" placeholder="Search"></strand-input>
 				<strand-list-item>Clicks</strand-list-item>
 				<strand-list-item>CTC</strand-list-item>
@@ -291,6 +291,10 @@
 				<strand-list-item>eCPM</strand-list-item>
 				<strand-list-item>PC CPA</strand-list-item>
 				<strand-list-item>PV CPA</strand-list-item>
+			</strand-dropdown>
+			<hr/>
+			<p><span class="bold">Dropdown:</span> Dynamic data, size small, skinless</p>
+			<strand-dropdown id="smallDataTest" placeholder="Select" size="small" skinless overflow="visible" max-items="5" unresolved>
 			</strand-dropdown>
 			<hr/>
 			<p><span class="bold">Dropdown:</span> Dynamic jQuery test</p>
@@ -326,7 +330,8 @@
 				dataTest = document.querySelector("#dataTest");
 				dataTestHidden = document.querySelector("#dataTestHidden");
 				dataTestShort = document.querySelector("#dataTestShort");
-				dataTest.data = dataTestHidden.data = dataTestShort.data = dataItems;
+				smallDataTest = document.querySelector("#smallDataTest");
+				dataTest.data = dataTestHidden.data = dataTestShort.data = smallDataTest.data = dataItems;
 				dataTest.value = dataTestHidden.value = 1;
 
 				// init jQuery test:

--- a/src/strand-list-item/index.html
+++ b/src/strand-list-item/index.html
@@ -41,6 +41,7 @@
 		</dom-module>
 		-->
 
+		<strand-list-item size="small">Item here that is small</strand-list-item>
 		<strand-list-item>Item here 00</strand-list-item>
 		<strand-list-item>I am a moderate amount of text. Just a bit but not too much</strand-list-item>
 		<strand-list-item >Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</strand-list-item>

--- a/src/strand-list-item/strand-list-item.scss
+++ b/src/strand-list-item/strand-list-item.scss
@@ -36,6 +36,12 @@
 	}
 }
 
+:host-context(strand-dropdown[size='small']),
+:host([size='small']) {
+	font-size: 11px !important;
+	line-height: 13px !important;
+}
+
 :host(:active) {
 	background: $color-D23;
 	color: $color-D2;
@@ -55,6 +61,6 @@
 	overflow: visible;
 }
 
-.highlight {
+:host > ::content .highlight {
 	background: $color-E13;
 }


### PR DESCRIPTION
- Ensure that styling for the size setting works in shadow
- Ensure highlight works in shadow
- Missed 'overflow-width' attr in docs
- Add example and clean up index.html

@dlasky  @shuwen - Addresses some of the gotchas which came up yesterday, super minor stuff but want to make sure you are in the loop.