### PR TITLE
Disallow end date later than start date

### DIFF
--- a/src/strand-datepicker/strand-datepicker.html
+++ b/src/strand-datepicker/strand-datepicker.html
@@ -94,7 +94,7 @@
 								<group rule="range" restrict="numeric" size="4"></group>
 							</strand-input-mask>
 						</div>
-						<strand-calendar id="endCalendar" date="{{endDate}}" pair-date="{{startDate}}" disable-past="{{startDate}}" disable-future="{{allowedEnd}}" on-calendar-select="_handleTap" disabled$="{{!endEnabled}}" date-format="{{dateFormat}}"></strand-calendar>
+						<strand-calendar id="endCalendar" date="{{endDate}}" pair-date="{{startDate}}" disable-past="{{_disableFuture(dual,startDate,allowedStart)}}" disable-future="{{allowedEnd}}" on-calendar-select="_handleTap" disabled$="{{!endEnabled}}" date-format="{{dateFormat}}"></strand-calendar>
 						<template is="dom-if" if="{{useTime}}">
 							<div class="input-bottom">
 								<strand-group>

--- a/src/strand-datepicker/strand-datepicker.js
+++ b/src/strand-datepicker/strand-datepicker.js
@@ -282,13 +282,15 @@
 			}
 			var sd = moment(this.startDate, this.dateFormat, true);
 			var allowedStart = _undef(this.allowedStart) && moment(this.allowedStart);
-			if (sd.isValid()) {
+			if (sd.isValid() && !this._resetStart) {
+				var ed = moment(this.endDate, this.dateFormat, true);
+
 				if (allowedStart && allowedStart.isValid() && sd.isBefore(allowedStart)) {
 					this.async(function() {
 						this.startDate = allowedStart.format(this.dateFormat);
 					});
 				}
-				else if (sd.isAfter(moment(this.endDate))) {
+				else if (ed.isValid() && sd.isAfter(ed)) {
 					this.async(function() {
 						this.startDate = this.endDate;
 					});
@@ -303,12 +305,14 @@
 			}
 			var ed = moment(this.endDate, this.dateFormat, true);
 			var allowedEnd = _undef(this.allowedEnd) && moment(this.allowedEnd);
-			if (ed.isValid()) {
+			if (ed.isValid() && !this._resetEnd) {
+				var sd = moment(this.startDate, this.dateFormat, true);
+
 				if (allowedEnd && allowedEnd.isValid() && ed.isAfter(allowedEnd)) {
 					this.async(function() {
 						this.endDate = allowedEnd.format(this.dateFormat);
 					});
-				} else if (ed.isBefore(moment(this.startDate))) {
+				} else if (sd.isValid() && ed.isBefore(sd)) {
 					this.async(function() {
 						this.endDate = this.startDate;
 					});
@@ -347,12 +351,14 @@
 			var e = moment(end);
 
 			if (s.isValid()) {
+				this._resetStart = true;
 				this.startDate = s.format(this.dateFormat);
 				this.startTime = s.format(this.timeOnlyFormat);
 				this.startTimePeriod = s.format('a');
 			}
 
 			if (e.isValid()) {
+				this.resetEnd = true;
 				this.endDate = e.format(this.dateFormat);
 				this.endTime = e.format(this.timeOnlyFormat);
 				this.endTimePeriod = e.format('a');

--- a/src/strand-datepicker/strand-datepicker.js
+++ b/src/strand-datepicker/strand-datepicker.js
@@ -275,7 +275,10 @@
 			return sd.isValid() && (!this.dual || ed.isValid());
 		},
 
-		_validateStart: function() {
+		_validateStart: function(startDate) {
+			if(startDate && startDate.length !== 10) {
+				this.startDate = moment(new Date(startDate)).format(this.dateFormat);
+			}
 			if(this.startDate instanceof Date) {
 				this.startDate = this._calendarFilter(this.startDate);
 				return;
@@ -298,7 +301,10 @@
 			}
 		},
 
-		_validateEnd: function() {
+		_validateEnd: function(endDate) {
+			if(endDate && endDate.length !== 10) {
+				this.endDate = moment(new Date(endDate)).format(this.dateFormat);
+			}
 			if(this.endDate instanceof Date) {
 				this.endDate = this._calendarFilter(this.endDate);
 				return;

--- a/src/strand-datepicker/strand-datepicker.js
+++ b/src/strand-datepicker/strand-datepicker.js
@@ -420,22 +420,20 @@
 		},
 
 		_save: function(e,_,silent) {
-			var s = moment(this.start, this.dateFormat, true);
-			var sd = moment(this.startDate, this.dateFormat, true);
+			var s = moment(this.start);
+			var sd = moment(this.startDate);
 			var st = moment(this.startTime + ' ' + this.startTimePeriod, this.timeFormat);
 			sd.set({'hours': st.hours(), 'minutes': st.minutes()});
 
-			if(_datesValid) {
-				var e = moment(this.end, this.dateFormat, true);
-				var ed = moment(this.endDate, this.dateFormat, true);
-				var et = moment(this.endTime + ' ' + this.endTimePeriod, this.timeFormat);
-				ed.set({'hours': et.hours(), 'minutes': et.minutes()});
+			var e = moment(this.end);
+			var ed = moment(this.endDate);
+			var et = moment(this.endTime + ' ' + this.endTimePeriod, this.timeFormat);
+			ed.set({'hours': et.hours(), 'minutes': et.minutes()});
 
-				if (s.isValid() && !s.isSame(sd))
-				this.start = sd.toDate();
-				if (e.isValid() && !e.isSame(ed))
-				this.end = ed.toDate();
-			}
+			if (s.isValid() && !s.isSame(sd))
+			this.start = sd.toDate();
+			if (e.isValid() && !e.isSame(ed))
+			this.end = ed.toDate();
 
 			if(!silent) {
 				this.fire('saved', { start:this.start, end:this.end });

--- a/src/strand-datepicker/strand-datepicker.js
+++ b/src/strand-datepicker/strand-datepicker.js
@@ -288,6 +288,11 @@
 						this.startDate = allowedStart.format(this.dateFormat);
 					});
 				}
+				else if (sd.isAfter(moment(this.endDate))) {
+					this.async(function() {
+						this.startDate = this.endDate;
+					});
+				}
 			}
 		},
 
@@ -302,6 +307,10 @@
 				if (allowedEnd && allowedEnd.isValid() && ed.isAfter(allowedEnd)) {
 					this.async(function() {
 						this.endDate = allowedEnd.format(this.dateFormat);
+					});
+				} else if (ed.isBefore(moment(this.startDate))) {
+					this.async(function() {
+						this.endDate = this.startDate;
 					});
 				}
 			}

--- a/src/strand-datepicker/strand-datepicker.js
+++ b/src/strand-datepicker/strand-datepicker.js
@@ -420,20 +420,22 @@
 		},
 
 		_save: function(e,_,silent) {
-			var s = moment(this.start);
-			var sd = moment(this.startDate);
+			var s = moment(this.start, this.dateFormat, true);
+			var sd = moment(this.startDate, this.dateFormat, true);
 			var st = moment(this.startTime + ' ' + this.startTimePeriod, this.timeFormat);
 			sd.set({'hours': st.hours(), 'minutes': st.minutes()});
 
-			var e = moment(this.end);
-			var ed = moment(this.endDate);
-			var et = moment(this.endTime + ' ' + this.endTimePeriod, this.timeFormat);
-			ed.set({'hours': et.hours(), 'minutes': et.minutes()});
+			if(_datesValid) {
+				var e = moment(this.end, this.dateFormat, true);
+				var ed = moment(this.endDate, this.dateFormat, true);
+				var et = moment(this.endTime + ' ' + this.endTimePeriod, this.timeFormat);
+				ed.set({'hours': et.hours(), 'minutes': et.minutes()});
 
-			if (s.isValid() && !s.isSame(sd))
-			this.start = sd.toDate();
-			if (e.isValid() && !e.isSame(ed))
-			this.end = ed.toDate();
+				if (s.isValid() && !s.isSame(sd))
+				this.start = sd.toDate();
+				if (e.isValid() && !e.isSame(ed))
+				this.end = ed.toDate();
+			}
 
 			if(!silent) {
 				this.fire('saved', { start:this.start, end:this.end });

--- a/src/strand-input-mask/strand-input-mask.js
+++ b/src/strand-input-mask/strand-input-mask.js
@@ -300,8 +300,8 @@
 						var rng = _groupRange(node.attributes.size.value),
 							rule = this.rules[node.attributes.rule.value],
 							restrict = this.restrict[node.attributes.restrict.value],
-							auto = node.attributes.autofill ? node.attributes.autofill.value : false,
-							// auto = false,
+							// auto = node.attributes.autofill.value,
+							auto = false,
 							args = node.textContent.trim(),
 							style = {
 								width:"auto"
@@ -312,10 +312,10 @@
 							index: i,
 							id:"mini"+i,
 							max:rng[1],
-							min:rng[0],
-							rule:rule,
+							min:rng[0], 
+							rule:rule, 
 							restrict:restrict,
-							args:args,
+							args:args, 
 							auto:auto,
 							type:_types.GROUP,
 							style:style,
@@ -332,10 +332,10 @@
 						var chars = node.attributes.chars.value;
 						this._sepsLen += chars.length;
 						var s = {
-							type:_types.SEP,
-							value:chars,
+							type:_types.SEP, 
+							value:chars, 
 							style: this.classBlock({
-								sep: true,
+								sep: true, 
 								placeholder: true
 							})
 						};
@@ -402,7 +402,7 @@
 
 		_handleFocus: function(e) {
 			this._updateGroups();
-			this._handleInputFocus();
+			this._handleInputFocus();       
 		},
 
 		_handleInputFocus: function(e) {
@@ -411,7 +411,6 @@
 
 		_handleBlur: function(e) {
 			this.$.input.$$("input").removeAttribute("forceFocus");
-			this._handleFill(e.target);
 		},
 
 		_handleCut: function(e) {
@@ -446,7 +445,7 @@
 		},
 
 		_validateGroup: function(e,target) {
-			var val = (e instanceof ClipboardEvent) ? e.clipboardData.getData('text/plain') :
+			var val = (e instanceof ClipboardEvent) ? e.clipboardData.getData('text/plain') : 
 				String.fromCharCode(e.keyCode);
 			var group = this._getGroup(target);
 
@@ -503,9 +502,9 @@
 			if(this._isKeyboardShortcut(e)) return;
 			var max = this._getGroup(e.target).max,
 				selLength = e.target.selectionEnd - e.target.selectionStart;
-			if(!this._validateGroup(e,e.target)) {
+			if(!this._validateGroup(e,e.target)) { 
 				e.preventDefault();
-			} else if(e.target.value.length === max && selLength === 0) {
+			} else if(e.target.value.length === max && selLength === 0) { 
 				this._validateGroup(e,this._focusRight(e.target));
 			}
 		},
@@ -520,7 +519,7 @@
 				if(oldTarget !== newTarget) newTarget.selectionStart = newTarget.selectionEnd = newTarget.value.length;
 			}
 		},
-
+		
 		_onRight: function(e) {
 			var max = this._getGroup(e.target).max,
 				selLength = e.target.selectionEnd - e.target.selectionStart;
@@ -530,7 +529,7 @@
 				if(oldTarget !== newTarget) newTarget.selectionStart = newTarget.selectionEnd = 0;
 			}
 		},
-
+		
 		_onTab: function(e) {
 			this._handleFill(e.target);
 		},

--- a/src/strand-input-mask/strand-input-mask.js
+++ b/src/strand-input-mask/strand-input-mask.js
@@ -300,8 +300,8 @@
 						var rng = _groupRange(node.attributes.size.value),
 							rule = this.rules[node.attributes.rule.value],
 							restrict = this.restrict[node.attributes.restrict.value],
-							// auto = node.attributes.autofill.value,
-							auto = false,
+							auto = node.attributes.autofill ? node.attributes.autofill.value : false,
+							// auto = false,
 							args = node.textContent.trim(),
 							style = {
 								width:"auto"
@@ -312,10 +312,10 @@
 							index: i,
 							id:"mini"+i,
 							max:rng[1],
-							min:rng[0], 
-							rule:rule, 
+							min:rng[0],
+							rule:rule,
 							restrict:restrict,
-							args:args, 
+							args:args,
 							auto:auto,
 							type:_types.GROUP,
 							style:style,
@@ -332,10 +332,10 @@
 						var chars = node.attributes.chars.value;
 						this._sepsLen += chars.length;
 						var s = {
-							type:_types.SEP, 
-							value:chars, 
+							type:_types.SEP,
+							value:chars,
 							style: this.classBlock({
-								sep: true, 
+								sep: true,
 								placeholder: true
 							})
 						};
@@ -402,7 +402,7 @@
 
 		_handleFocus: function(e) {
 			this._updateGroups();
-			this._handleInputFocus();       
+			this._handleInputFocus();
 		},
 
 		_handleInputFocus: function(e) {
@@ -411,6 +411,7 @@
 
 		_handleBlur: function(e) {
 			this.$.input.$$("input").removeAttribute("forceFocus");
+			this._handleFill(e.target);
 		},
 
 		_handleCut: function(e) {
@@ -445,7 +446,7 @@
 		},
 
 		_validateGroup: function(e,target) {
-			var val = (e instanceof ClipboardEvent) ? e.clipboardData.getData('text/plain') : 
+			var val = (e instanceof ClipboardEvent) ? e.clipboardData.getData('text/plain') :
 				String.fromCharCode(e.keyCode);
 			var group = this._getGroup(target);
 
@@ -502,9 +503,9 @@
 			if(this._isKeyboardShortcut(e)) return;
 			var max = this._getGroup(e.target).max,
 				selLength = e.target.selectionEnd - e.target.selectionStart;
-			if(!this._validateGroup(e,e.target)) { 
+			if(!this._validateGroup(e,e.target)) {
 				e.preventDefault();
-			} else if(e.target.value.length === max && selLength === 0) { 
+			} else if(e.target.value.length === max && selLength === 0) {
 				this._validateGroup(e,this._focusRight(e.target));
 			}
 		},
@@ -519,7 +520,7 @@
 				if(oldTarget !== newTarget) newTarget.selectionStart = newTarget.selectionEnd = newTarget.value.length;
 			}
 		},
-		
+
 		_onRight: function(e) {
 			var max = this._getGroup(e.target).max,
 				selLength = e.target.selectionEnd - e.target.selectionStart;
@@ -529,7 +530,7 @@
 				if(oldTarget !== newTarget) newTarget.selectionStart = newTarget.selectionEnd = 0;
 			}
 		},
-		
+
 		_onTab: function(e) {
 			this._handleFill(e.target);
 		},

--- a/test/strand-datepicker.html
+++ b/test/strand-datepicker.html
@@ -8,7 +8,7 @@
   <script src="../bower_components/web-component-tester/browser.js"></script>
   <script src="TestHelper.js"></script>
   <script>
-    var should = chai.should();
+	var should = chai.should();
   </script>
   <link rel="import" href="../build/strand.html">
 </head>
@@ -16,9 +16,11 @@
 <strand-button id="target1"><label>Open Datepicker</label></strand-button>
 <strand-button id="target2"><label>Open Datepicker</label></strand-button>
 <strand-button id="target3"><label>Open Datepicker</label></strand-button>
+<strand-button id="target4"><label>Open Datepicker</label></strand-button>
 <strand-datepicker id="test1" target="#target1"></strand-datepicker>
 <strand-datepicker id="test2" target="#target2"></strand-datepicker>
 <strand-datepicker id="test3" target="#target3"></strand-datepicker>
+<strand-datepicker id="test4" target="#target4"></strand-datepicker>
 <script>
 describe("strand-datepicker", function() {
 
@@ -103,6 +105,16 @@ describe("strand-datepicker", function() {
 		});
 	});
 
+	it("should not allow a manually entered end date to be before a start date", function(done) {
+		var t4 = document.querySelector("#test4");
+		var sd = moment();
+		var ed = moment().subtract(3, 'days');
+		t4.startDate = sd.format(t4.dateFormat);
+		t4.endDate = ed.format(t4.dateFormat);
+		flush(function() {
+			t4.endDate.should.equal(t4.startDate);
+		});
+	});
 });
 </script>
 </body>

--- a/test/strand-datepicker.html
+++ b/test/strand-datepicker.html
@@ -17,10 +17,12 @@
 <strand-button id="target2"><label>Open Datepicker</label></strand-button>
 <strand-button id="target3"><label>Open Datepicker</label></strand-button>
 <strand-button id="target4"><label>Open Datepicker</label></strand-button>
+<strand-button id="target5"><label>Open Datepicker</label></strand-button>
 <strand-datepicker id="test1" target="#target1"></strand-datepicker>
 <strand-datepicker id="test2" target="#target2"></strand-datepicker>
 <strand-datepicker id="test3" target="#target3"></strand-datepicker>
 <strand-datepicker id="test4" target="#target4"></strand-datepicker>
+<strand-datepicker id="test5" target="#target5"></strand-datepicker>
 <script>
 describe("strand-datepicker", function() {
 
@@ -113,6 +115,17 @@ describe("strand-datepicker", function() {
 		t4.endDate = ed.format(t4.dateFormat);
 		flush(function() {
 			t4.endDate.should.equal(t4.startDate);
+			done();
+		});
+	});
+
+	it("should not allow a manually entered but badly formatted end date to be before a start date", function(done) {
+		var t5 = document.querySelector("#test5");
+		var sd = moment('7/10/2016');
+		t5.startDate = sd.format(t5.dateFormat);
+		t5.endDate = "7/1 /2016";
+		flush(function() {
+			t5.endDate.should.equal(t5.startDate);
 			done();
 		});
 	});

--- a/test/strand-datepicker.html
+++ b/test/strand-datepicker.html
@@ -113,6 +113,7 @@ describe("strand-datepicker", function() {
 		t4.endDate = ed.format(t4.dateFormat);
 		flush(function() {
 			t4.endDate.should.equal(t4.startDate);
+			done();
 		});
 	});
 });


### PR DESCRIPTION
Inputting an end date before the start date from the text field will now cause the field to snap back to the start date, and vice versa for start date after end date

@dlasky @anthonykoerber 
fyi @amakaa