### PR TITLE
strand-repeater rewrite

### DIFF
--- a/docs/articles/repeater.md
+++ b/docs/articles/repeater.md
@@ -1,67 +1,60 @@
-# Using strand-repeater
+# Working with strand-repeater
 
 ## Overview
-
 `strand-repeater` allows the duplication of a set of fields contained within a template tag.
 
+`strand-repeater-row` has three bindable properties (like `strand-grid-item`):
+- `model`, a reference to javascript object with the data filling the row
+- `scope`, a reference to the `strand-repeater` the row is contained in
+- `index`, the index of the row's model within the repeater's `data`
+
+So if you wanted to take a list of _n_ addresses, you could set up:
 ```html
 <strand-repeater id="myRepeater">
 	<template preserve-content>
-		<strand-input name="first_name" placeholder="First Name"></strand-input>
-		<strand-input name="last_name" placeholder="Last Name"></strand-input>
-		<strand-input name="address" placeholder="Address"></strand-input>
-		<strand-input name="city" placeholder="City"></strand-input>
-		<strand-dropdown name="state" placeholder="State/Province">
-			...
-		</strand-dropdown>
-		<strand-input name="zip_code" placeholder="ZIP/Postal Code"></strand-input>
+		<strand-repeater-row model="{{model}}" scope="{{scope}}" index="{{index}}">
+			<span>{{index}}</span>
+			<strand-input name="first_name" placeholder="First Name" value="{{model.first_name}}"></strand-input>
+			<strand-input name="last_name" placeholder="Last Name" value="{{model.last_name}}"></strand-input>
+			<strand-input name="address" placeholder="Address" value="{{model.address}}"></strand-input>
+			<strand-input name="city" placeholder="City" value="{{model.city}}"></strand-input>
+			<strand-dropdown name="state" placeholder="State/Province" value="{{model.state}}">
+				...
+			</strand-dropdown>
+			<strand-input name="zip_code" placeholder="ZIP/Postal Code" value="{{model.zip_code}}"></strand-input>
+		</strand-repeater-row>
 	</template>
 </strand-repeater>
 ```
+Binding the values of the form input to the model means that the javascript object will update when the value of the form fields update.
 
-## Validation
-Like `strand-form`, `strand-repeater` takes a `config` object, which can take `validation` as a `string` or a custom validation method taking the arguments `value, row:Object, domref:HTMLElement`, and an `errorMessage`. If a custom validation method is used, `this.errorMessage` can be set dynamically.
-
-```javascript
-var myRepeater = document.getElementById('myRepeater'),
-	Validator = StrandLib.Validator;
-myRepeater.config = {
-	'first_name': {
-		validation: 'alpha'
-	},
-	'last_name': {
-		validation: 'alpha'
-	},
-	'address': {
-		validation: function(value) {
-			var a = value.split(" "),
-				street_num = parseInt(a[0]),
-				street_name = a[1];
-			return street_num != NaN;
-		},
-	},
-	'city': {
-		validation: 'alpha'
-	},
-	'zip_code': {
-		validation: function(zip) {
-			var z = zip.replace('-','');
-			return parseInt(z) != NaN && (z.length == 5 || z.length == 9);
-		},
-		errorMessage: 'Not a valid ZIP'
-	}
-}
+Binding works just like in a custom `strand-grid-item`, so, for example, to disable a specific form field based on the value of a property in the model, you could write something like this:
+```html
+<strand-repeater>
+	<template preserve-content>
+		<strand-repeater-row model="{{model}}" scope="{{scope}}">
+			<strand-input name="name" placeholder="Name" value="{{model.name}}" disabled$="{{model.locked}}"></strand-input>
+		</strand-repeater-row>
+	</template>
+</strand-repeater>
 ```
+This will create an attribute binding to the `disabled` property of the input, so the user will not be able to modify the inputs of rows that are "locked".
 
-## Getting data from `strand-repeater`
-User data from repeated form fields are accessible through the `value` property on the `strand-repeater` element. `value` is a getter/setter interface for the `data` property—this ensures Polymer's data binding updates properly. Each object in the `value` array corresponds to a single repeater row, with key-value pairs corresponding to the name-value pairs of the form elements.
+## Reading data from `strand-repeater`
+`strand-repeater` has four public arrays that are exactly what they say on the tin:
+- `data` contains all of the data in the repeater
+- `added` contains only the models that have been added by the user
+- `modified` contains only the pre-populated models that have been modified
+- `deleted` contains the models that have been removed by the user (and are therefore no longer in `data`)
+You will find these arrays on any element that implements the `Collection` behavior such as `strand-collection`. Each model also gets a `cId` property (distinct from the index) which will be useful to identify models [when validating](#validation).
 
-## Getting data into `strand-repeater`
+`strand-repeater` also has a `value` attribute that is just a getter/setter pair for `data`, allowing you to drop it into a larger `strand-form`.
 
-Data can be preloaded into the repeater by setting the `value`. This is useful in views where the end user wishes to edit some pre-existing data.
+## Pre-populating data
+Data can be pre-populated into the repeater by setting `data`. This is useful in views where the user wishes to edit some pre-existing collection of data.
 ```javascript
 var myRepeater = document.getElementById('myRepeater');
-myRepeater.value = [
+myRepeater.data = [
 	{
 		first_name: "Jerry",
 		last_name: "Seinfeld",
@@ -80,4 +73,42 @@ myRepeater.value = [
 	}
 ];
 ```
-By default, `strand-repeater` initializes the `value` property with an array containing a single, empty `Object`. This results in a single, blank instance of the template being rendered when the form loads.
+By default `data` will contain one array with an empty object, giving you a single row with all fields blank.
+
+## Validation
+You can assign a function to `strand-repeater`'s `validation` property, which the element will use to validate user input, set error state, and display error messages. When you call `validate()` on the repeater, that subsequently calls `validation` with four parameters, which are the `data`, `added`, `modified`, and `deleted` arrays (in that order) and should return an array of invalid models with error messages. There are two requirements for this to work properly:
+- The `name` attribute of each form field you want to validate must match the name of the property its `value` is bound to. So in our example above, we have `<strand-input name="first_name" value="{{model.first_name}}">`.
+- The models that `validation` returns must include the `cId` (which you can just pass through)
+
+The easiest way to do this is with ES5 array `map` and `filter`:
+```javascript
+function validateAddr(address) {
+	if(!address) return 'Address required!';
+	var tmp = address.split(' ');
+	if(Number.isNaN(parseInt(tmp[0]))) return 'Street number required!';
+}
+
+function validateZip(zip) {
+	if(!zip) return 'ZIP required!';
+	var zip5 = zip.length === 5 && !Number.isNaN(parseInt(zip));
+	var zip9 = zip.length === 10 && zip.split('-').reduce(function(acc, current, index) {
+		return !Number.isNaN(parseInt(current)) && acc;
+	});
+	return (zip5 || zip9) ? null : 'ZIP is invalid!'
+}
+
+myRepeater.validation = function(data, added, modified, removed) {
+	return data.map(function(model) {
+		return {
+			cId: model.cId,
+			first_name: model.first_name ? null : 'First name required!',
+			last_name: model.last_name ? null : 'Last name required!',
+			address: validateAddr(model.address),
+			city: model.city ? null : 'City required!',
+			state: model.state ? null : 'State required!',
+			zip_code: validateZip(model.zip)
+		}
+	});
+};
+```
+The repeater considers the field invalid if an error message is present. It will set the error state on the associated element if possible and add an error message below the form element, which will persist until the next call of `validate()`.

--- a/src/shared/behaviors/collection.html
+++ b/src/shared/behaviors/collection.html
@@ -164,9 +164,8 @@
 		_deepChanged:function(change) {
 			if (change && change.path) {
 				var path = change.path.split(".");
-				if (path.length > 1) {
-					var idx = parseInt(path[1].substr(1));
-					var model = this.data[idx];
+				if (path.length > 1 && path[1].charAt(0) === '#') {
+					var model = Polymer.Base.get('data.'+path[1], this);
 					this.fire('added-changed');
 					this.fire('removed-changed');
 					this.fire('modified-changed');
@@ -174,9 +173,9 @@
 					if (model && this.getIndexOfCid(model.cId,'added') === -1
 						&& this.getIndexOfCid(model.cId, 'modified') === -1) {
 
-						this.push('modified', this.data[idx]);
-						this._cleanHelperArrays('added',this.data[idx]);
-						this._cleanHelperArrays('removed',this.data[idx]);
+						this.push('modified', model);
+						this._cleanHelperArrays('added', model);
+						this._cleanHelperArrays('removed', model);
 					}
 				} else if (change.path === 'data' && this.data) {
 					this._resetHelperArrays();

--- a/src/shared/behaviors/validatable.html
+++ b/src/shared/behaviors/validatable.html
@@ -22,8 +22,13 @@
 				value: false
 			},
 			validation: {
-				type: String,
+				type: Object,
 				observer: "_validationChanged"
+			},
+
+			_customValidation: {
+				type: Boolean,
+				value: false
 			}
 		},
 
@@ -31,8 +36,10 @@
 		testSet: null,
 
 		_validationChanged: function(newVal, oldVal) {
-			if (newVal) {
+			if (typeof newVal === 'string') {
 				this.testSet = newVal.replace(/\s/g, '').split("|");
+			} else if(typeof newVal === 'function') {
+				this.set('_customValidation', true);
 			}
 		},
 
@@ -46,7 +53,9 @@
 		},
 
 		validate: function(value) {
-			if(this.validation) {
+			if(this._customValidation) {
+				return this.validation(value);
+			} else if(this.validation) {
 				var result = this.testSet.map(function(item) {
 					return Validator.rules[item](value);
 				}, this).filter(function(item) {

--- a/src/strand-dropdown/strand-dropdown.js
+++ b/src/strand-dropdown/strand-dropdown.js
@@ -59,7 +59,7 @@
 				type:Boolean,
 				notify: true,
 				value: false
-			},			
+			},
 			index: {
 				type:Number,
 				notify:true,
@@ -76,9 +76,9 @@
 				type: Boolean,
 				value: false
 			},
-			layout: { 
+			layout: {
 				type: String,
-				reflectToAttribute: true 
+				reflectToAttribute: true
 			},
 			data: {
 				type: Array,
@@ -154,7 +154,7 @@
 		},
 
 		_selectItemByValue: function(value) {
-			this.async(function(){
+			Polymer.RenderStatus.afterNextRender(this, function(){
 				var item = null;
 				var valueStr = value.toString();
 
@@ -264,6 +264,7 @@
 				var name = newSelected.name ? newSelected.name : newSelected.textContent.trim();
 
 				this.value = value;
+				this.error = false;
 
 				if (this.data) {
 					this.set('data.' + newIndex + '.selected', true);

--- a/src/strand-form-message/strand-form-message.html
+++ b/src/strand-form-message/strand-form-message.html
@@ -5,6 +5,7 @@
 
 -->
 <link rel="import" href="../../bower_components/polymer/polymer.html"/>
+<link rel="import" href="../shared/behaviors/refable.html" />
 <link rel="import" href="../shared/behaviors/resolvable.html" />
 <link rel="import" href="../strand-inline-box/strand-inline-box.html" />
 
@@ -16,4 +17,3 @@
 </dom-module>
 
 <script src="strand-form-message.js"></script>
-

--- a/src/strand-form-message/strand-form-message.js
+++ b/src/strand-form-message/strand-form-message.js
@@ -5,11 +5,12 @@
 
 */
 (function (scope) {
-	
+
 	scope.FormMessage = Polymer({
 		is: 'strand-form-message',
 
 		behaviors: [
+			StrandTraits.Refable,
 			StrandTraits.Resolvable
 		],
 
@@ -25,7 +26,7 @@
 				value: false
 			}
 		},
-	
+
 	});
 
 })(window.Strand = window.Strand || {});

--- a/src/strand-form-message/strand-form-message.scss
+++ b/src/strand-form-message/strand-form-message.scss
@@ -20,3 +20,9 @@ strand-inline-box[visible] {
 	display: block;
 	margin-top: 10px;
 }
+
+:host-context(strand-repeater) {
+	strand-inline-box[visible] {
+		margin-top: 4px;
+	}
+}

--- a/src/strand-repeater-row/strand-repeater-row.html
+++ b/src/strand-repeater-row/strand-repeater-row.html
@@ -1,0 +1,46 @@
+<!--
+ * @license
+ * Copyright (c) 2015 MediaMath Inc. All rights reserved.
+ * This code may only be used under the BSD style license found at http://mediamath.github.io/strand/LICENSE.txt
+
+-->
+<link rel="import" href="../../bower_components/polymer/polymer.html"/>
+<link rel="import" href="../shared/fonts/fonts.html"/>
+<link rel="import" href="../shared/behaviors/lightdomgettable.html"/>
+<link rel="import" href="../shared/behaviors/refable.html"/>
+<link rel="import" href="../shared/behaviors/resolvable.html"/>
+<link rel="import" href="../shared/behaviors/templatefindable.html"/>
+<link rel="import" href="../shared/behaviors/stylable.html"/>
+<link rel="import" href="../shared/behaviors/validatable.html"/>
+<link rel="import" href="../shared/js/validator.html"/>
+<link rel="import" href="../shared/js/datautils.html"/>
+<link rel="import" href="../strand-action/strand-action.html"/>
+<link rel="import" href="../strand-box/strand-box.html"/>
+<link rel="import" href="../strand-icon/strand-icon.html"/>
+<link rel="import" href="../strand-form-message/strand-form-message.html"/>
+
+<dom-module id="strand-repeater-row">
+	<link rel="import" type="css" href="strand-repeater-row.css" />
+	<template>
+		<div class$="{{_computeContainerClass(index, scope._last)}}">
+			<div class="row-wrapper">
+				<div class="content-wrapper">
+					<content id="content"></content>
+				</div>
+				<strand-box class="control" align="center">
+					<strand-action class="add-row" on-tap="_addRow" hidden$="{{!_shouldShowAddRow}}"><label>{{scope.addRowLabel}}</label></strand-action>
+					<template is="dom-if" if="{{scope._showRemove}}">
+						<strand-icon class="remove-row" type="delete" on-tap="_removeRow" height="12" width="12"></strand-icon>
+					</template>
+				</strand-box>
+			</div>
+			<div class="error-container row-wrapper">
+				<template is="dom-repeat" id="errorRepeat" items="{{errors}}">
+					<strand-form-message class="error-message" type="error" visible$="{{item.message}}" message="{{item.message}}" style$="{{_computeErrorMessageStyle(item)}}"></strand-form-message>
+				</template>
+			</div>
+		</div>
+	</template>
+</dom-module>
+
+<script src="strand-repeater-row.js"></script>

--- a/src/strand-repeater-row/strand-repeater-row.js
+++ b/src/strand-repeater-row/strand-repeater-row.js
@@ -1,0 +1,114 @@
+(function(scope) {
+	var DataUtils = StrandLib.DataUtils;
+
+	scope.RepeaterRow = Polymer({
+		is: 'strand-repeater-row',
+
+		behaviors: [
+			StrandTraits.LightDomGettable,
+			StrandTraits.Stylable
+		],
+
+		properties: {
+			model: {
+				type: Object,
+				notify: true,
+				observer: '_modelChanged'
+			},
+			scope: {
+				type: Object,
+				notify: true
+			},
+			index: {
+				type: Number
+			},
+
+			errors: {
+				type: Array,
+				value: false,
+				notify: true
+			},
+
+			_shouldShowAddRow: {
+				type: Boolean,
+				computed: '_computeShouldShowAddRow(index, scope._last, scope.maxRows)',
+				notify: true
+			}
+		},
+
+		observers: [
+			'_notifyModelChanged(model.*)'
+		],
+
+		_notifyModelChanged: function(changeRecord) {
+			this.scope._notifyModelChanged(changeRecord);
+		},
+
+		_addRow: function() {
+			this.scope.add();
+		},
+
+		_removeRow: function(ev) {
+			this.scope.remove(this.index);
+		},
+
+		_computeContainerClass: function(index, last) {
+			var o = {};
+			o["container"] = true;
+			o["has-bottom-margin"] = index !== last;
+			return this.classBlock(o);
+		},
+
+		_computeShouldShowAddRow: function(index, last, maxRows) {
+			return (index === last) && (maxRows ? last < maxRows-1 : true);
+		},
+
+		_computeErrorMessageStyle: function(record) {
+			if(record.elt && record.elt instanceof HTMLElement) {
+				var current = record.elt,
+					prev = Polymer.dom(current).previousElementSibling,
+
+					rowRect = this.getBoundingClientRect(),
+					rect = current.getBoundingClientRect(),
+					prevRect = prev ? prev.getBoundingClientRect() : null,
+
+					width = rect.width,
+					position = rect.left - rowRect.left,
+					offset = prev ? (prevRect.right - rowRect.left) : 0,
+
+					s = {
+						left: (position-offset)+"px",
+						width: width+"px"
+					};
+
+				return this.styleBlock(s);
+			}
+		},
+
+		_validate: function(record) {
+			var custom = DataUtils.isDef(record) && record.cId === this.model.cId;
+			var elems = Array.prototype.slice.call( Polymer.dom(this).querySelectorAll('[name],[error]') )
+			this.errors = elems
+				.map(function(node) {
+					var name = node.getAttribute('name');
+					var message = custom ? record[name] : '';
+					var error = node.error || !!message; // validatable has set the error state, or error message is present
+					node.error = error;
+
+					return {
+						name: name,
+						message: message,
+						error: error,
+						elt: node
+					};
+				})
+				.filter(DataUtils.isDef);
+				
+			return this.errors.filter(function(o) { return o.error; }).length === 0;
+		},
+
+		_modelChanged: function(newModel) {
+			this.scope._validation[newModel.cId] = this._validate.bind(this);
+		}
+	});
+})(window.Strand = window.Strand || {});

--- a/src/strand-repeater-row/strand-repeater-row.scss
+++ b/src/strand-repeater-row/strand-repeater-row.scss
@@ -1,0 +1,58 @@
+@import 'color';
+
+.container {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.has-bottom-margin {
+	margin-bottom: 6px;
+}
+
+.row-wrapper {
+	display: flex;
+	align-content: space-between;
+	position: relative;
+	width: 100%;
+}
+
+:host ::content,
+.content-wrapper {
+	display: flex;
+	align-content: flex-start;
+	align-items: center;
+	flex: 1;
+}
+
+.content-wrapper ::content > :not(:last-child) {
+	margin-right: 8px;
+}
+
+.hidden {
+	display: none;
+	pointer-events: none;
+}
+
+.control {
+	width: auto;
+}
+
+.add-row {
+	cursor: pointer;
+	margin: 0 10px;
+}
+
+.remove-row {
+	color: $color-A6;
+	cursor: pointer;
+}
+
+.error-container {
+	position: relative;
+}
+
+[hidden] {
+	display: none;
+	pointer-events: none;
+}

--- a/src/strand-repeater/doc.json
+++ b/src/strand-repeater/doc.json
@@ -1,21 +1,16 @@
 {
 	"name":"strand-repeater",
 	"description":"A component for duplicating a set of form fields from a template",
-	"experimental" : [
-		{
-			"message" : "This component contains experimental features. The configuration and API are subject to change. Please use at your own risk."
-		}
-	],
 	"attributes": [
 		{
-			"name":"value",
+			"name":"data",
 			"type":"Array",
 			"description":"An array containing key:value maps of the strand-repeater data, one per row"
 		},
 		{
-			"name":"config",
-			"type":"Object",
-			"description":"An configuration object used to provide validation rules and error messaging"
+			"name":"maxRows",
+			"type":"Integer",
+			"description":"Maximum number of rows before user can no longer add more (setting this <= 0 means no limit)"
 		},
 		{
 			"name":"addRowLabel",
@@ -30,7 +25,7 @@
 			"description":"A read-only array of key:value maps of rows that have been added by the user"
 		},
 		{
-			"name":"changed",
+			"name":"modified",
 			"type":"Array",
 			"readOnly":"true",
 			"description":"A read-only array of key:value maps of rows that have been modified by the user"

--- a/src/strand-repeater/index.html
+++ b/src/strand-repeater/index.html
@@ -4,7 +4,7 @@
 		<script language="javascript" src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../strand.html" />
 
-		<style type="text/css">
+		<style type="text/css" is="custom-style">
 			body, html {
 				height: 100%;
 				min-height: 100%;
@@ -21,29 +21,13 @@
 				-moz-box-sizing: border-box;
 				box-sizing: border-box;
 				display: block;
-				float: left;
 				padding: 0 20px;
-				font-size: 0;
-			}
-
-			.col.c0 {
-				width:400px;
-			}
-
-			.col.c1 {
-				width:300px;
-			}
-
-			.col.c2 {
-				width:200px;
-			}
-
-			.col.c3 {
-				width:500px;
 			}
 
 			.col.c4 {
-				width:100%;
+				margin-left: auto;
+				margin-right: auto;
+				width: 80%;
 			}
 
 			.col:after {
@@ -64,122 +48,197 @@
 			}
 
 			.bold { font-weight: bold; }
-
-			hr {
-				border: 0;
-				display: block;
-					border-bottom: 1px solid #fff;
-					border-top: 1px solid #ccc;
-					height: 0px;
-					margin-top: 20px;
-			}
-
-			.vr {
-				width:0px;
-				height: 100%;
-				border-right: 1px solid #fff;
-				border-left: 1px solid #ccc;
-				display: block;
-				float: left;
-			}
-
 		</style>
 	</head>
 	<body>
-		<div id='container' class="col c4">
-			<strand-repeater id="repeater">
-				<template preserve-content>
-					<strand-input name="name"></strand-input>
-					<strand-dropdown name="firstOption">
-						<strand-list-item>Test Item 1</strand-list-item>
-						<strand-list-item>Test Item 2</strand-list-item>
-						<strand-list-item>Test Item 3</strand-list-item>
-						<strand-list-item>Test Item 4</strand-list-item>
-					</strand-dropdown>
-					<strand-group name="secondOption">
-						<strand-radio><label>Test 1</label></strand-radio>
-						<strand-radio><label>Test 2</label></strand-radio>
-						<strand-radio><label>Test 3</label></strand-radio>
-					</strand-group>
-				</template>
-			</strand-repeater>
+		<dom-module id="test-repeater-view">
+			<style>
+				.data-display {
+					background-color: #d9d9d9;
+					color: #333;
+					border-radius: 5px;
+					font-family: monospace;
+					font-size: 16px;
+					padding: 1em;
+					margin: 1em 0;
+				}
 
-			<hr style="margin-bottom: 30px;">
+				.wrapper {
+					display: block;
+					margin: 1em 0;
+				}
 
-			<strand-header>Prepopulated</strand-header>
-			<strand-repeater id="withData">
-				<template preserve-content>
-					<strand-input name="name" validation="alpha"></strand-input>
-					<strand-input name="number"></strand-input>
-					<strand-dropdown name="firstOption">
-						<strand-list-item>Test Item 1</strand-list-item>
-						<strand-list-item>Test Item 2</strand-list-item>
-						<strand-list-item>Test Item 3</strand-list-item>
-						<strand-list-item>Test Item 4</strand-list-item>
-					</strand-dropdown>
-					<strand-group name="secondOption">
-						<strand-radio><label>Test 1</label></strand-radio>
-						<strand-radio><label>Test 2</label></strand-radio>
-						<strand-radio><label>Test 3</label></strand-radio>
-					</strand-group>
-				</template>
-			</strand-repeater>
+				#repeater {
+					margin-bottom: 1em;
+				}
+			</style>
 
-			<strand-button style="margin: 10px 0;" id="validateBtn"><label>Validate!</label></strand-button>
+			<template>
+				<div class="wrapper">
+					<strand-header size="large">strand-repeater</strand-header>
+				</div>
 
+				<strand-repeater mixin-findable="{{mixinFindable}}" added="{{myAdded}}" removed="{{myRemoved}}" modified="{{myModified}}" data="{{myData}}" id="repeater" add-row-label="+Custom Add Row Label">
+					<template preserve-content>
+						<strand-repeater-row model="{{model}}" scope="{{scope}}" index="{{index}}">
+							<strand-input name="name" validation="blank" value="{{model.name}}" disabled="{{model.disabled}}"></strand-input>
+							<strand-dropdown placeholder="Select a Test Item" name="firstOption" value="{{model.firstOption}}" overflow="visible" disabled="{{model.disabled}}" width="150px">
+								<strand-list-item>Test Item 1</strand-list-item>
+								<strand-list-item>Test Item 2</strand-list-item>
+								<strand-list-item>Test Item 3</strand-list-item>
+								<strand-list-item>Test Item 4</strand-list-item>
+							</strand-dropdown>
+							<strand-group name="secondOption" value="{{model.secondOption}}" disabled="{{model.disabled}}">
+								<strand-radio><label>Test 1</label></strand-radio>
+								<strand-radio><label>Test 2</label></strand-radio>
+								<strand-radio><label>Test 3</label></strand-radio>
+							</strand-group>
+						</strand-repeater-row>
+					</template>
+				</strand-repeater>
+
+				<div class="wrapper">
+					<strand-header size="small">Data</strand-header>
+					<div class="data-display">{{formatData(myData.*, _refresh)}}</div>
+					<strand-header size="small">Added</strand-header>
+					<div class="data-display">{{formatData(myAdded.*, _refresh)}}</div>
+					<strand-header size="small">Modified</strand-header>
+					<div class="data-display">{{formatData(myModified.*, _refresh)}}</div>
+					<strand-header size="small">Removed</strand-header>
+					<div class="data-display">{{formatData(myRemoved.*, _refresh)}}</div>
+				</div>
+
+
+				<strand-button type="secondary" on-tap="refreshData"><label>Refresh Arrays</label></strand-button>
+				<strand-button id="addBunchBtn" on-tap="addABunchOfRows"><label>Add a Bunch of Rows</label></strand-button>
+				<strand-button on-click="validateRepeater" id="validateBtn"><label>Validate!</label></strand-button>
+			</template>
+		</dom-module>
+
+		<div class="col c4">
+			<test-repeater-view></test-repeater-view>
 		</div>
 
 		<script>
-			var acceptedNames = ['John', 'Paul', 'George', 'Ringo'];
-			var config = {
-				'name': {
-					validation: function(name) {
-						return acceptedNames.indexOf(name) >= 0;
-					},
-					errorMessage: 'Name is not in the list of accepted values'
-				},
-				'number': {
-					validation: 'int',
-					errorMessage: 'Not an integer'
-				},
-				'firstOption': {
-					validation: function() {
-						return true;
-					}
-				},
-				'secondOption': {
-					validation: function() {
-						return true;
-					}
-				}
-			};
-
 			var data = [
 				{
-					name: "John",
-					firstOption: "Test Item 2",
+					name: "Barclay",
+					firstOption: "Test Item 1",
 					secondOption: "Test 1"
 				},
 				{
-					name: "Paul",
-					firstOption: "Test Item 1",
+					name: "Barry",
 					secondOption: "Test 2"
 				},
 				{
-					name: "Ringo",
+					name: "Bart",
+					secondOption: "Test 3"
+				},
+				{
+					name: "Bert",
 					firstOption: "Test Item 1",
 					secondOption: "Test 3"
+				},
+				{
+					name: "Bort",
+					secondOption: "Test 3",
+					disabled: true
 				}
 			];
 
 			window.addEventListener('WebComponentsReady', function(e) {
-				var wd = document.querySelector('#withData');
-				// wd.set('data', data);
-				wd.config = config;
-				wd.value = data;
+				Polymer({
+					is: 'test-repeater-view',
 
-				document.querySelector('#validateBtn').addEventListener('click', function() {
-					wd.validate();
+					properties: {
+						myData: {
+							type: Array,
+							notify: true
+						},
+						myAdded: {
+							type: Array,
+							notify: true
+						},
+						myModified: {
+							type: Array,
+							notify: true
+						},
+						myRemoved: {
+							type: Array,
+							notify: true
+						},
+
+						_refresh: {
+							type: Boolean,
+							value: true,
+							notify: true
+						}
+					},
+
+					behaviors: [
+						StrandTraits.MixinFindable
+					],
+
+					observers: [
+						'_dataChanged(myData.*)'
+					],
+
+					_dataChanged: function(changeRecord) {
+						if(changeRecord && changeRecord.path.substr(0,8) === 'myData.#') this.refreshData();
+					},
+
+					validateRepeater: function() {
+						this.$.repeater.validate();
+					},
+
+					addABunchOfRows: function() {
+						for(let i=0; i<25; i++) this.$.repeater.add();
+					},
+
+					formatData: function(record) {
+						return JSON.stringify(record.base || record.value);
+					},
+
+					refreshData: function() {
+						this._refresh = !this._refresh;
+					},
+
+					ready: function() {
+						this.set('myData', data);
+
+						this.$.repeater.validation = function(data, added, modified, removed) {
+							var acceptedValues = ['Barclay', 'Barry', 'Bert', 'Bort'];
+
+							return data.map(function(datum) {
+								return {
+									cId: datum.cId,
+									name: (function(name) {
+										if(name === 'Bart') {
+											return "Name not accepted"
+										} else if(name === 'Bort') {
+											return "Out of Bort license plates"
+										}
+									})(datum.name),
+									firstOption: datum.firstOption ? null : "Must be selected"
+								}
+							});
+						}
+					},
+
+					mixinsForValuePath: function(template, path) {
+						if(path[0] === 'properties') {
+							return [{
+								myValidation: {
+									type: Function,
+									value: function() {
+										return function(str) {
+											return ''+str === 'AAA';
+										}
+									}
+								}
+							}];
+						}
+					}
 				});
 			});
 		</script>

--- a/src/strand-repeater/strand-repeater.html
+++ b/src/strand-repeater/strand-repeater.html
@@ -6,28 +6,30 @@
 -->
 <link rel="import" href="../../bower_components/polymer/polymer.html"/>
 <link rel="import" href="../shared/fonts/fonts.html"/>
+<link rel="import" href="../shared/behaviors/collection.html"/>
+<link rel="import" href="../shared/behaviors/dommutable.html"/>
 <link rel="import" href="../shared/behaviors/refable.html"/>
 <link rel="import" href="../shared/behaviors/resolvable.html"/>
+<link rel="import" href="../shared/behaviors/mixinfindable.html"/>
+<link rel="import" href="../shared/behaviors/templatefindable.html"/>
 <link rel="import" href="../shared/behaviors/validatable.html"/>
 <link rel="import" href="../shared/js/validator.html"/>
 <link rel="import" href="../shared/js/datautils.html"/>
-<link rel="import" href="../strand-action/strand-action.html"/>
-<link rel="import" href="../strand-box/strand-box.html"/>
-<link rel="import" href="../strand-icon/strand-icon.html"/>
-<link rel="import" href="../strand-form-message/strand-form-message.html"/>
+<link rel="import" href="../strand-repeater-row/strand-repeater-row.html"/>
+<link rel="import" href="../strand-template-finder/strand-template-finder.html"/>
+<link rel="import" href="../strand-componentizer/strand-componentizer.html"/>
 
 <dom-module id="strand-repeater">
 	<link rel="import" type="css" href="strand-repeater.css"/>
 	<template>
-		<template is="dom-repeat" items="{{data}}" id="repeater">
-			<strand-box ref="{{item._ref}}" align="stretch" justify="space-between" on-selected="_updateModel" on-changed="_updateModel">
-				<div class="fields" align="center" inner-h-t-m-l="{{template}}"></div>
-				<strand-box class="control" align="center">
-					<strand-action on-tap="_addRow"><label>{{addRowLabel}}</label></strand-action>
-					<strand-icon type="delete" on-tap="_removeRow" height="12" width="12"></strand-icon>
-				</strand-box>
-			</strand-box>
-			<strand-form-message type="error" visible="{{item.error}}" message="{{item.errorMessage}}"></strand-form-message>
+		<strand-template-finder template-finder="{{templateFinder}}" template-findable="{{templateFindable}}">
+			<content select="template:not([is])"></content>
+		</strand-template-finder>
+
+		<template is="dom-if" if="{{_templateFound}}">
+			<template is="dom-repeat" items="{{data}}" id="repeat">
+				<strand-componentizer scope="{{ref}}" model="{{item}}" index="{{index}}" mixin-findable="{{mixinFindable}}" template-finder="{{templateFinder}}" template-findable="{{templateFindable}}"></strand-componentizer>
+			</template>
 		</template>
 	</template>
 </dom-module>

--- a/src/strand-repeater/strand-repeater.js
+++ b/src/strand-repeater/strand-repeater.js
@@ -7,205 +7,108 @@
 (function(scope) {
 
 	var Validator = StrandLib.Validator,
+		BehaviorUtils = StrandLib.BehaviorUtils,
 		DataUtils = StrandLib.DataUtils;
 
 	scope.Repeater = Polymer({
 		is: 'strand-repeater',
 
 		properties: {
-			config: {
-				type: Object,
-				value: function() { return {}; }
-			},
 			data: {
 				type: Array,
 				notify: true,
-				value: function() { return [{}]; },
-				observer: '_handleDataChanged'
-			},
-			template: {
-				type: Object,
-				value: null
-			},
-			added: {
-				type: Array,
-				value: []
-			},
-			removed: {
-				type: Array,
-				value: []
-			},
-			_origData: {
-				type: Array,
-				value: []
+				value: function() { return [{}]; }
 			},
 			addRowLabel: {
 				type: String,
 				value: '+Add Item'
+			},
+
+			// new
+			maxRows: {
+				type: Number,
+				value: 0,
+				notify: true
+			},
+
+			_last: {
+				type: Number,
+				value: -1,
+				notify: true
+			},
+			_validation: {
+				type: Object,
+				value: function() { return {}; }
+			},
+			_showRemove: {
+				type: Boolean,
+				notify: true
 			}
 		},
 
 		behaviors: [
+			StrandTraits.Collection,
 			StrandTraits.Refable,
-			StrandTraits.Resolvable
+			StrandTraits.Resolvable,
+			StrandTraits.MixinFindable,
+			StrandTraits.TemplateFindable,
+			StrandTraits.DomMutable
 		],
 
-		get changed() {
-			return this._origData.filter(function(elt) { return elt._changed; });
-		},
+		observers: [
+			'_dataLengthChanged(data.length)'
+		],
 
 		get value() {
 			return this.data;
 		},
 
 		set value(newVal) {
-			if (newVal instanceof Array) {
-				this.set('data', newVal);
+			if (Array.isArray(newVal)) this.set('data', newVal);
+		},
+
+		add: function(model, silent, force) {
+			if(this.maxRows <= 0 || this.data.length < this.maxRows) {
+				var inherited = BehaviorUtils.findSuper(StrandTraits.Collection, "add");
+				inherited.call(this, model || {}, silent, force);
 			}
 		},
 
-		observers: [
-			'_handleDataPath(data.*)'
-		],
-
-		// Temp warning message
-		created: function() {
-			console.warn('This component contains experimental features. The configuration and API are subject to change. Please use at your own risk.');
-		},
-
-		_handleDataPath: function(e) {
-			var path = e.path.split('.'),
-				record = path[path.length-1];
-
-			if(record === 'splices')
-				this._handleSplices(e);
-			else if(record === '_ref') {
-				var index = parseInt(path[1].substring(1));
-				this._injectModelData(index);
+		_notifyModelChanged: function(modelChangeRecord) {
+			// strand-repeater-row calls this to bridge mutation events from its model to strand-repeater's data array
+			if(modelChangeRecord.path) {
+				var idx = this.data.indexOf(modelChangeRecord.base);
+				var path = modelChangeRecord.path.replace('model.', 'data.'+idx+'.');
+				this.notifyPath(path, modelChangeRecord.value);
 			}
 		},
 
-		_handleSplices: function(e) {
-			e.value.indexSplices.forEach(function(record) {
-				// TODO: Make this less awful
-				this.set('added', this.added.concat(
-					record.addedKeys.map(
-						function(key) {
-							return record.object[parseInt(key.substring(1))];
-						}
-					)
-				));
-				this.set('removed', this.removed.concat(record.removed));
-			}.bind(this));
+		_dataLengthChanged: function(length) {
+			this.set('ref._last', length-1);
+			this.set('ref._showRemove', length > 1);
 		},
 
-		_handleDataChanged: function(newData, oldData) {
-			if(oldData) {
-				// Because of binding weirdness we need to move _refs manually from the old array to the new array
-				for(var i=oldData.length-1; i>= 0; i--) {
-					newData[i]._ref = oldData[i]._ref;
-				}
+		validate: function(validation) {
+			var errors = [];
+			if(!validation) validation = this.validation;
+
+			if(DataUtils.isType(validation, 'function')) {
+				this._errorModels = validation.call(this, this.data, this.added, this.modified, this.removed);
+
+				var cIds = this.data.map(function(o) { return o.cId });
+
+				// Call the error state setting method on each row
+				errors = cIds.map(function(key) {
+					var record;
+					var cId = parseInt(key);
+					var errIndex = this.getIndexOfCid(cId, '_errorModels');
+
+					if(errIndex >= 0) record = this._errorModels[errIndex];
+					return this._validation[key](record);
+				}, this);
 			}
 
-			this.set('_origData', newData.slice(0));
-
-			for(var j=newData.length-1; j>= 0; j--) {
-				this._injectModelData(j);
-			}
-		},
-
-		_injectModelData: function(index, data) {
-			if(!data) data = this.data;
-
-			var model = data[index],
-				node = model && model._ref;
-
-			if(node) {
-				var fields = node.querySelectorAll('[name]');
-				for(var i=0; i<fields.length; i++) {
-					var field = fields[i],
-						name = field.getAttribute('name');
-					if(model[name]) field.setAttribute('value', model[name]);
-				}
-			}
-		},
-
-		ready: function() {
-			var templateTag = this.queryEffectiveChildren('template');
-			this.set('template', templateTag.innerHTML);
-		},
-
-		validate: function() {
-			return this.data.reduce(function(sum, row) {
-				var valid = this.validateRow(row);
-				return sum && valid;
-			}.bind(this), true);
-		},
-
-		validateRow: function(row) {
-			var keys = Object.keys(row);
-			var errorMessage = "";
-
-			var valid = keys.reduce(function(sum, key) {
-				var validation = DataUtils.getPathValue(key+'.validation', this.config);
-				var valid = true;
-				var validatef = null;
-
-				switch(typeof validation) {
-					case "function":
-						valid = validation.call(this.config[key], row[key], row, row._ref);
-						break;
-					case "string":
-						validatef = Validator.rules[validation];
-						if(validatef) valid = validatef(row[key]);
-						break;
-					default:
-						break;
-				}
-
-				var el = row._ref.querySelector('[name='+key+']');
-				if(el) el.error = !valid;
-
-				if(!valid) {
-					var message = DataUtils.getPathValue(key+'.errorMessage', this.config);
-					errorMessage += ' '+message;
-				}
-				return sum && valid;
-			}.bind(this), true);
-
-			var prefix = 'data.' + this.data.indexOf(row) + '.';
-			this.set(prefix+'error', !valid);
-			this.set(prefix+'errorMessage', errorMessage.trim());
-
-			return valid;
-		},
-
-		validation: this.validate,
-
-		_updateModel: function(e) {
-			var target = Polymer.dom(e).rootTarget,
-				name = target.name || target.getAttribute('name'),
-				value = target.value || target.getAttribute('value');
-
-			if(name && value !== e.model.get('item.'+name)) {
-				e.model.set('item._changed', true);
-				e.model.set('item.'+name, value);
-				this.debounce('changed', this._changed);
-			}
-		},
-
-		_addRow: function() {
-			this.push('data', {});
-		},
-
-		_removeRow: function(e) {
-			var index = this.$.repeater.indexForElement(e.target);
-			this.splice('data', index, 1);
-			this.debounce('changed', this._changed);
-		},
-
-		_changed: function() {
-			this.fire('changed', { value: this.data });
+			return errors.reduce(function(all, current) { return all && current; }, true);
 		}
 	});
 

--- a/src/strand-repeater/strand-repeater.scss
+++ b/src/strand-repeater/strand-repeater.scss
@@ -9,46 +9,6 @@
 @import "_color";
 @import "_mixins";
 
-strand-box:first-of-type:last-of-type {
-    .control strand-icon {
-        display: none;
-        pointer-events: none;
-    }
-}
-
-strand-box:not(:last-of-type) {
-    margin-bottom: 10px;
-
-    .control strand-action {
-        display: none;
-        pointer-events: none;
-    }
-}
-
-strand-icon[type="delete"] {
-    cursor: pointer;
-    margin-left: 10px;
-}
-
-// strand-inline-box[type="error"] {
-//     display: block;
-//     margin: 10px 0;
-//     width: 100%;
-// }
-
-strand-form-message {
-    margin-bottom: 10px;
-}
-
-.fields,
-::content .fields {
-    font-size: 0em;
-
-    & > :not(:last-child) {
-        margin-right: 10px;
-    }
-}
-
-.control strand-icon {
-    color: $color-A6;
+:host {
+    display: block;
 }

--- a/src/strand.html
+++ b/src/strand.html
@@ -37,6 +37,7 @@
 <link rel="import" href="strand-progress-bar/strand-progress-bar.html">
 <link rel="import" href="strand-pulldown-button/strand-pulldown-button.html">
 <link rel="import" href="strand-repeater/strand-repeater.html">
+<link rel="import" href="strand-repeater-row/strand-repeater-row.html">
 <link rel="import" href="strand-radio/strand-radio.html">
 <link rel="import" href="strand-scroll-panel/strand-scroll-panel.html">
 <link rel="import" href="strand-scrollbar-y/strand-scrollbar-y.html">

--- a/test/strand-dropdown.html
+++ b/test/strand-dropdown.html
@@ -99,7 +99,7 @@
 				var ddl = document.getElementById('ddl');
 
 				ddl.value = 2;
-				flush(function() {
+				Polymer.RenderStatus.afterNextRender(ddl, function() {
 					ddl.selectedIndex.should.equal(1);
 					done();
 				});
@@ -109,7 +109,7 @@
 				var ddl = document.getElementById('ddl');
 
 				ddl.value = "3";
-				flush(function() {
+				Polymer.RenderStatus.afterNextRender(ddl, function() {
 					ddl.selectedIndex.should.equal(2);
 					done();
 				});

--- a/test/strand-repeater.html
+++ b/test/strand-repeater.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<script src="../bower_components/webcomponentsjs/webcomponents.js"></script>
+	<script src="../bower_components/web-component-tester/browser.js"></script>
+	<script src="TestHelper.js"></script>
+	<script>
+		var should = chai.should();
+	</script>
+	<link rel="import" href="../build/strand.html">
+</head>
+<body>
+
+	<strand-repeater id="repeater">
+		<template preserve-content>
+			<strand-repeater-row model="{{model}}" scope="{{scope}}">
+				<strand-input name="value" value="{{model.value}}"></strand-input>
+			</strand-repeater-row>
+		</template>
+	</strand-repeater>
+
+	<script>
+		describe("strand-repeater", function() {
+
+			it("should exist", function() {
+				var a = new Strand.Repeater();
+				a.nodeName.should.equal("STRAND-REPEATER");
+			});
+
+			it("should respect max-rows", function() {
+				var a = new Strand.Repeater();
+				a.maxRows = 3;
+				a.data = [{},{},{}];
+				a.add({});
+				expect(a.data.length).to.equal(3);
+			});
+
+			it("should validate", function(done) {
+				var a = document.querySelector('#repeater');
+				a.data = [{value: 7}, {value: 8}, {value: 'Soda'}];
+				a.validation = function(data) {
+					return data.map(function(model) {
+						return {
+							cId: model.cId,
+							value: typeof model.value === 'number' ? null : 'Invalid'
+						}
+					});
+				};
+				flush(function() {
+					var isValid = a.validate();
+					expect(isValid).to.equal(false);
+					done();
+				});
+			});
+
+		});
+
+	</script>
+
+</body>
+</html>


### PR DESCRIPTION
Rewrite of `strand-repeater` to leverage `strand-componentizer` for binding and Collection.html for collection management

Breaking changes:
- `strand-repeater-row` is required in the template
- removes validation configuration object in favor of doing it in a user-defined `validation` function

please review @dlasky @jcmoore @anthonykoerber 
fyi @jeremysklarsky 