### PR TITLE
Hover over strand-list-item to account for L/R padding

### DIFF
--- a/src/strand-list-item/strand-list-item.js
+++ b/src/strand-list-item/strand-list-item.js
@@ -81,7 +81,8 @@
 		updateTitle: function() {
 			var m = StrandLib.Measure;
 			var computed = m.textWidth(this, this.textContent);
-			var actual = m.getBoundingClientRect(this).width;
+			var padding = parseInt(getComputedStyle(this).paddingLeft.split('px')[0]) + parseInt(getComputedStyle(this).paddingRight.split('px')[0]);
+			var actual = m.getBoundingClientRect(this).width - padding;
 			if (computed > actual) {
 				var txt = this.textContent.trim();
 				if (this.title !== txt)

--- a/src/strand-list-item/strand-list-item.js
+++ b/src/strand-list-item/strand-list-item.js
@@ -6,6 +6,8 @@
 */
 
 (function (scope) {
+	var Measure = StrandLib.Measure;
+
 	scope.ListItem = Polymer({
 
 		is: "strand-list-item",
@@ -81,8 +83,7 @@
 		updateTitle: function() {
 			var m = StrandLib.Measure;
 			var computed = m.textWidth(this, this.textContent);
-			var padding = parseInt(getComputedStyle(this).paddingLeft.split('px')[0]) + parseInt(getComputedStyle(this).paddingRight.split('px')[0]);
-			var actual = m.getBoundingClientRect(this).width - padding;
+			var actual = m.getBoundingClientRect(this).width - Measure.getPaddingWidth(this);
 			if (computed > actual) {
 				var txt = this.textContent.trim();
 				if (this.title !== txt)


### PR DESCRIPTION
Because of 20px worth of padding, `strand-list-item` content in a dropdown is truncated before `computed > actual` will evaluate to true. So items that are slightly too long to be displayed in full but aren't long enough to overcome the padding are truncated, but no `title` is added to the element. 

This PR offsets the calculation by the element's left and right padding to account for the difference.