### PR TITLE
Autocomplete highlighting

### DIFF
--- a/src/strand-autocomplete/strand-autocomplete.html
+++ b/src/strand-autocomplete/strand-autocomplete.html
@@ -32,7 +32,8 @@
 			direction$="{{_updateInputDirection(state, direction)}}"
 			fitparent="{{fitparent}}"
 			width="{{width}}"
-			value="{{_name}}"></strand-input>
+			value="{{_name}}"
+			autocomplete="off"></strand-input>
 		<div id="panel" on-tap="_updateSelectedItem">
 			<div id="container" class$="{{_containerClass(state, direction)}}">
 				<div id="list">

--- a/src/strand-autocomplete/strand-autocomplete.html
+++ b/src/strand-autocomplete/strand-autocomplete.html
@@ -38,9 +38,11 @@
 				<div id="list">
 					<template id="domRepeat" is="dom-repeat" items="{{_searchData}}">
 						<strand-list-item 
-							value$="{{item.value}}" 
-							selected$={{item.selected}}
-							highlighted$="{{item.highlighted}}">{{item.name}}</strand-list-item>
+							value="{{item.value}}" 
+							name="{{item.name}}"
+							selected="{{item.selected}}"
+							highlight="[[_name]]"
+							highlighted="{{item.highlighted}}"></strand-list-item>
 					</template>
 				</div>
 			</div>

--- a/src/strand-dropdown/doc.json
+++ b/src/strand-dropdown/doc.json
@@ -100,6 +100,14 @@
 			"optional":true,
 			"default":"none",
 			"reflect":true
+		},
+		{
+			"name":"highlight",
+			"type":"String",
+			"description":"Instructs the list items to show the passed string as highlighted text",
+			"optional":true,
+			"default":"''",
+			"reflect":false
 		}
 	],
 	"methods": [

--- a/src/strand-dropdown/strand-dropdown.html
+++ b/src/strand-dropdown/strand-dropdown.html
@@ -50,14 +50,16 @@
 					<strand-item-recycler
 						id="itemRecycler"
 						data="{{data}}"
+						scope="{{scope}}"
 						hidden$="{{!_hideInsertionPoints(data)}}"
 						index="{{index}}">
 						<template preserve-content>
 							<strand-list-item
 								value$="{{model.value}}"
 								selected$="{{model.selected}}"
-								highlight$="{{model.highlight}}"
-								highlighted$="{{model.highlighted}}">{{model.name}}</strand-list-item>
+								highlight$="{{scope.highlight}}"
+								name="{{model.name}}"
+								highlighted$="{{model.highlighted}}"></strand-list-item>
 						</template>
 					</strand-item-recycler>
 				</div>

--- a/src/strand-dropdown/strand-dropdown.js
+++ b/src/strand-dropdown/strand-dropdown.js
@@ -100,7 +100,8 @@
 			},
 			highlight: {
 				type:String,
-				notify: true
+				notify: true,
+				observer:'_highlightChanged'
 			},
 			maxItems: {
 				type: Number,
@@ -330,6 +331,10 @@
 				}
 			}
 			inherited.apply(this, [newIndex, oldIndex]);
+		},
+
+		_highlightChanged: function() {
+			this.notifyPath("scope.highlight", this.highlight);
 		},
 
 		_updateLabelText: function(selectedIndex, placeholder) {

--- a/src/strand-dropdown/strand-dropdown.js
+++ b/src/strand-dropdown/strand-dropdown.js
@@ -343,7 +343,7 @@
 			if (typeof selectedIndex === 'number') {
 				var selectedItem = this.items[selectedIndex];
 
-				label = this.data ? selectedItem.name : selectedItem.textContent.trim();
+				label = this.data ? selectedItem.name : Polymer.dom(selectedItem).textContent.trim();
 			}
 			return label;
 		},

--- a/src/strand-dropdown/strand-dropdown.js
+++ b/src/strand-dropdown/strand-dropdown.js
@@ -91,6 +91,17 @@
 				notify: true,
 				observer: '_valueChanged'
 			},
+			scope: {
+				type: Object,
+				notify: true,
+				value: function() {
+					return this;
+				}
+			},
+			highlight: {
+				type:String,
+				notify: true
+			},
 			maxItems: {
 				type: Number,
 				observer: '_maxItemsChanged'
@@ -194,7 +205,7 @@
 		},
 
 		_getValueFromDom: function(node) {
-			return node.getAttribute('value') || node.textContent.trim();
+			return node.getAttribute('value') || Polymer.dom(node).textContent.trim();
 		},
 
 		_getDataIndexFromDom: function(value) {

--- a/src/strand-input/strand-input.html
+++ b/src/strand-input/strand-input.html
@@ -25,8 +25,9 @@
 			value="{{value::input}}" 
 			maxlength$="{{maxlength}}" 
 			disabled="{{disabled}}"
-			readonly$="{{readonly}}" 
-			style$="{{ _updateStyle(width, fitparent) }}" />
+			readonly$="{{readonly}}"
+			style$="{{ _updateStyle(width, fitparent) }}" 
+			autocomplete$="{{autocomplete}}" />
 		<div id="icon" class="icon-holder" style$="{{ _updateIcon(icon, _clearVisible) }}">
 			<strand-icon type="{{icon}}" width="{{_iconSize(size)}}" height="{{_iconSize(size)}}"></strand-icon>
 		</div>

--- a/src/strand-input/strand-input.js
+++ b/src/strand-input/strand-input.js
@@ -91,7 +91,7 @@
 			},
 			autocomplete: {
 				type: String,
-				value: null
+				value: "off"
 			},
 			_clearVisible: {
 				type: Boolean,

--- a/src/strand-input/strand-input.js
+++ b/src/strand-input/strand-input.js
@@ -89,6 +89,10 @@
 				value: false, 
 				reflectToAttribute: true 
 			},
+			autocomplete: {
+				type: String,
+				value: null
+			},
 			_clearVisible: {
 				type: Boolean,
 				value: false

--- a/src/strand-list-item/strand-list-item.html
+++ b/src/strand-list-item/strand-list-item.html
@@ -21,7 +21,6 @@
 			<template is="dom-if" if="{{item.highlight}}"><mark>{{item.text}}</mark></template>
 			<template is="dom-if" if="{{!item.highlight}}">{{item.text}}</template>
 		</template>
-		</template>
 	</template>
 </dom-module>
 <script src="strand-list-item.js"></script>

--- a/src/strand-list-item/strand-list-item.html
+++ b/src/strand-list-item/strand-list-item.html
@@ -13,8 +13,15 @@
 
 <dom-module id="strand-list-item">
 	<link rel="import" type="css" href="strand-list-item.css"/>
-	<template>
-		<content></content>
+	<template strip-whitespace>
+		<div style="display:none">
+			<content id="content"></content>
+		</div>
+		<template is="dom-repeat" strip-whitespace items="{{_textItems}}">
+			<template is="dom-if" if="{{item.highlight}}"><mark>{{item.text}}</mark></template>
+			<template is="dom-if" if="{{!item.highlight}}">{{item.text}}</template>
+		</template>
+		</template>
 	</template>
 </dom-module>
 <script src="strand-list-item.js"></script>

--- a/src/strand-list-item/strand-list-item.js
+++ b/src/strand-list-item/strand-list-item.js
@@ -51,6 +51,11 @@
 			value: {
 				type: String,
 				value: false
+			},
+			name: {
+				type:String,
+				value: '',
+				observer:'_nameChanged'
 			}
 		},
 
@@ -61,6 +66,12 @@
 			"mouseover":"_updateTitleHandler"
 		},
 
+		ready: function() {
+			if (!this.name) {
+				this.name = this.getEffectiveChildNodes().map(function(n) { return n.textContent }).join('');
+			}
+		},
+
 		attached: function () {
 			this.debounce("update-title",this.updateTitle,0);
 		},
@@ -69,16 +80,43 @@
 			this.debounce("update-title",this.updateTitle,0);
 		},
 
+		_nameChanged: function() {
+			this.debounce('update-name', this._updateTextItems, 0);
+		},
+
 		_highlightChanged: function() {
-			if (this.highlight && this.highlight.length > 0) {
-				var s = this.innerText;
-				Polymer.dom(this).innerHTML = s.replace(new RegExp(this.highlight,"ig"),function(orig) {
-					return '<span class="strand-list-item highlight">'+orig+'</span>';
-				},'ig');
-			} else if (this.innerText && this.innerText.trim()){
-				Polymer.dom(this).innerHTML = this.innerText.trim(); //strip any formatting
+			// var s = Polymer.dom(this).textContent;
+			// if (this.highlight && this.highlight.length > 0 && s) {
+			// 	Polymer.dom(this).innerHTML = s.replace(new RegExp(this.highlight,"ig"),function(orig) {
+			// 		return '<mark class="strand-list-item highlight">'+orig+'</mark>';
+			// 	},'ig');
+			// } 
+			// else if (this.innerText && this.innerText.trim()){
+			// 	Polymer.dom(this).innerHTML = this.innerText.trim(); //strip any formatting
+			// }
+			this.debounce('update-name', this._updateTextItems, 0);
+		},
+
+		_updateTextItems: function() {
+			if (!this.name) return;
+			if (this.highlight) {
+				var reg = new RegExp(this.highlight.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"), 'ig');
+				var stamp = '\uE000';
+				this._textItems = this.name.replace(reg, function(o) { 
+					return stamp + o + stamp;
+				})
+				.split(stamp)
+				.map(function(input, i) {
+					return {
+						highlight: i%2!=0,
+						text: input
+					};
+				});
+			} else {
+				this._textItems = [{text:this.name}];
 			}
 		},
+
 
 		updateTitle: function() {
 			var m = StrandLib.Measure;

--- a/src/strand-list-item/strand-list-item.js
+++ b/src/strand-list-item/strand-list-item.js
@@ -85,15 +85,6 @@
 		},
 
 		_highlightChanged: function() {
-			// var s = Polymer.dom(this).textContent;
-			// if (this.highlight && this.highlight.length > 0 && s) {
-			// 	Polymer.dom(this).innerHTML = s.replace(new RegExp(this.highlight,"ig"),function(orig) {
-			// 		return '<mark class="strand-list-item highlight">'+orig+'</mark>';
-			// 	},'ig');
-			// } 
-			// else if (this.innerText && this.innerText.trim()){
-			// 	Polymer.dom(this).innerHTML = this.innerText.trim(); //strip any formatting
-			// }
 			this.debounce('update-name', this._updateTextItems, 0);
 		},
 
@@ -108,7 +99,7 @@
 				.split(stamp)
 				.map(function(input, i) {
 					return {
-						highlight: i%2!=0,
+						highlight: i%2!==0,
 						text: input
 					};
 				});

--- a/src/strand-list-item/strand-list-item.scss
+++ b/src/strand-list-item/strand-list-item.scss
@@ -64,3 +64,8 @@
 :host > ::content .highlight {
 	background: $color-E13;
 }
+
+mark {
+	color: $color-A2;
+	background: $color-E13;
+}

--- a/src/strand-pulldown-button/strand-pulldown-button.js
+++ b/src/strand-pulldown-button/strand-pulldown-button.js
@@ -87,7 +87,7 @@
 			if(typeof newIndex === 'number') {
 				var newSelected = this.items[newIndex],
 					oldSelected = this.items[oldIndex],
-					value = newSelected.value ? newSelected.value.toString() : newSelected.textContent.trim();
+					value = newSelected.value ? newSelected.value.toString() : Polymer.dom(newSelected).textContent.trim();
 
 				this.fire('selected', {
 					item: newSelected,

--- a/test/strand-dropdown.html
+++ b/test/strand-dropdown.html
@@ -124,8 +124,8 @@
 				ddl.selectedIndex = 2;
 				flush(function() {
 					selectedItem = ddl.items[ddl.selectedIndex];
-					selectedItemName = selectedItem.textContent.trim();
-					label = ddl._target.querySelector('label').textContent.trim();
+					selectedItemName = Polymer.dom(selectedItem).textContent.trim();
+					label = Polymer.dom(ddl._target.querySelector('label')).textContent.trim();
 					label.should.equal(selectedItemName);
 					done();
 				});


### PR DESCRIPTION
- support for highlighting in autocomplete
- lighter support for highlighting in data dropdowns (bound to the scope of DDL now so we dont have to update every single model just to pass highlighting)
- list-item now supports `name` property by default
- list-item highlight no longer unsafely munges the `innerHTML`

the `mark` node is a new HTML5 thing if you are wondering what that is. Also it appears to cleanly ignore pointerEvents so it doesnt mess up any of the close filtering stuff unlike `span` which did without an added `pointer-events:none`

@shuwen @anthonykoerber 