### PR TITLE
Resolve a safari/FF issue where a DDL inside a drawer will lose its e…

### DIFF
--- a/src/shared/behaviors/autotogglable.html
+++ b/src/shared/behaviors/autotogglable.html
@@ -21,6 +21,10 @@
 			this._boundToggle = this._toggle.bind(this);
 		},
 
+		attached: function() {
+			this._addListener(this.toggleTrigger);
+		},
+
 		detached: function() {
 			this._removeListener(this.toggleTrigger);
 		},


### PR DESCRIPTION
…vent listener

it looks like for some reason browsers other than chrome seem to add and remove the dropdown a bunch inside the drawer (6x -- probably for content tag distribution) which seems to break the AutoClosable behavior because detached is called which permanently removes the listener.


@anthonykoerber @sassomedia @shuwen 